### PR TITLE
Add missing parameter to get (Close issue #38)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 # cookies 0.1.1
 
+* Added `get_cookie()` to easily get cookies with in the server.
+* Added `missing` as a parameter to `get_cookie()` and `extract_cookie()` for when the cookie doesn't exist.
+* Changed the default behavior for missing cookies from `NA` to `NULL` to be more in line with R convention.
 * Updated a test. No user-facing changes.
 
 # cookies 0.1.0

--- a/R/requests.R
+++ b/R/requests.R
@@ -5,6 +5,8 @@
 #'
 #' @inheritParams extract_cookies
 #' @inheritParams .shared-parameters
+#' @param missing The value to return if the requested cookie is not stored in
+#' the request. Defaults to NULL.
 #'
 #' @return The contents of that cookie.
 #' @export
@@ -14,13 +16,13 @@
 #' extract_cookie(req, "cookie2")
 #' extract_cookie(list(), "cookie1")
 #' extract_cookie(NULL, "cookie1")
-extract_cookie <- function(request, cookie_name) {
+extract_cookie <- function(request, cookie_name, missing=NULL) {
   cookies <- extract_cookies(request = request)
 
   if (length(cookies) && cookie_name %in% names(cookies)) {
     return(cookies[[cookie_name]])
   } else {
-    return(NA_character_)
+    return(missing)
   }
 }
 

--- a/R/requests.R
+++ b/R/requests.R
@@ -16,7 +16,7 @@
 #' extract_cookie(req, "cookie2")
 #' extract_cookie(list(), "cookie1")
 #' extract_cookie(NULL, "cookie1")
-extract_cookie <- function(request, cookie_name, missing=NULL) {
+extract_cookie <- function(request, cookie_name, missing = NULL) {
   cookies <- extract_cookies(request = request)
 
   if (length(cookies) && cookie_name %in% names(cookies)) {

--- a/R/requests.R
+++ b/R/requests.R
@@ -6,7 +6,7 @@
 #' @inheritParams extract_cookies
 #' @inheritParams .shared-parameters
 #' @param missing The value to return if the requested cookie is not stored in
-#' the request. Defaults to NULL.
+#' the request. Defaults to `NULL`.
 #'
 #' @return The contents of that cookie.
 #' @export

--- a/R/server.R
+++ b/R/server.R
@@ -75,6 +75,8 @@ remove_cookie <- function(cookie_name,
 #'
 #' @inheritParams .shared-parameters
 #' @inheritParams shiny::moduleServer
+#' @param missing The value to return if the requested cookie does not exist.
+#' Defaults to NULL.
 #'
 #' @return A character with the value of the cookie.
 #' @export
@@ -83,9 +85,10 @@ remove_cookie <- function(cookie_name,
 #'   get_cookie("my_cookie")
 #' }
 get_cookie <- function(cookie_name,
+                       missing = NULL,
                        session = shiny::getDefaultReactiveDomain()) {
   # Once the cookies are initialized, use the input value.
   session$input$cookies[[cookie_name]] %||%
     # But when the app first loads, the cookies are only in the request object.
-    extract_cookie(session$request, cookie_name)
+    extract_cookie(session$request, cookie_name, missing)
 }

--- a/man/extract_cookie.Rd
+++ b/man/extract_cookie.Rd
@@ -4,7 +4,7 @@
 \alias{extract_cookie}
 \title{Extract an individual cookie from a shiny request}
 \usage{
-extract_cookie(request, cookie_name)
+extract_cookie(request, cookie_name, missing = NULL)
 }
 \arguments{
 \item{request}{A shiny request object.}
@@ -12,6 +12,9 @@ extract_cookie(request, cookie_name)
 \item{cookie_name}{The name of the cookie. Can contain any US-ASCII
 characters except for: the control character, space, a tab, or separator
 characters like ( ) < > @ , ; : \\ " / [ ] ? = \{ \}.}
+
+\item{missing}{The value to return if the requested cookie is not stored in
+the request. Defaults to \code{NULL}.}
 }
 \value{
 The contents of that cookie.

--- a/man/get_cookie.Rd
+++ b/man/get_cookie.Rd
@@ -4,12 +4,19 @@
 \alias{get_cookie}
 \title{Read a cookie}
 \usage{
-get_cookie(cookie_name, session = shiny::getDefaultReactiveDomain())
+get_cookie(
+  cookie_name,
+  missing = NULL,
+  session = shiny::getDefaultReactiveDomain()
+)
 }
 \arguments{
 \item{cookie_name}{The name of the cookie. Can contain any US-ASCII
 characters except for: the control character, space, a tab, or separator
 characters like ( ) < > @ , ; : \\ " / [ ] ? = \{ \}.}
+
+\item{missing}{The value to return if the requested cookie does not exist.
+Defaults to NULL.}
 
 \item{session}{Session from which to make a child scope (the default should
 almost always be used).}

--- a/tests/testthat/test-requests.R
+++ b/tests/testthat/test-requests.R
@@ -17,18 +17,30 @@ test_that("extract_cookie works", {
 
   expect_identical(
     extract_cookie(req_missing, "testcookie"),
+    NULL
+  )
+  expect_identical(
+    extract_cookie(req_missing, "testcookie", NA_character_),
     NA_character_
+  )
+  expect_identical(
+    extract_cookie(req_missing, "testcookie", "special default"),
+    "special default"
   )
   expect_identical(
     extract_cookie(req_empty, "testcookie"),
-    NA_character_
+    NULL
   )
   expect_identical(
     extract_cookie(req_other, "testcookie"),
-    NA_character_
+    NULL
   )
   expect_identical(
     extract_cookie(req_only_test, "testcookie"),
+    "expected_value"
+  )
+  expect_identical(
+    extract_cookie(req_only_test, "testcookie", NA_character_),
     "expected_value"
   )
   expect_identical(


### PR DESCRIPTION
This closes issue #38 by adding a `missing` field to get and extract. 

Previously the default behavior for missing values was to return an NA, this PR changes the default behavior to returning a NULL. NULL is more in line with R convention for extracting a missing value (like a nonexistent entry in a list, for instance). So this does break existing behavior, but since the missing field exists if people want the NA they can easily set it back.