### PR TITLE
Temporarily deal with over-zealous http-only check.

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -95,7 +95,7 @@ server <- function(input, output, session) {
   observeEvent(
     input$number_selector,
     {
-      cookies::set_cookie(
+      set_cookie(
         cookie_name = "selected_number",
         cookie_value = input$number_selector
       )

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ server <- function(input, output, session) {
   observeEvent(
     input$number_selector,
     {
-      cookies::set_cookie(
+      set_cookie(
         cookie_name = "selected_number",
         cookie_value = input$number_selector
       )

--- a/tests/testthat/test-server.R
+++ b/tests/testthat/test-server.R
@@ -75,7 +75,7 @@ test_that("remove_cookie works.", {
 })
 
 test_that("get_cookie works.", {
-  session$input <- list()
+  session$input <- list(cookies_start = list(key = "value"))
   session$request <- list(HTTP_COOKIE = "key=value")
   expect_identical(
     get_cookie("key", session = session),


### PR DESCRIPTION
Closes #63.

When I rewrite handling to store things in session$userData, make sure this is dealt with more cleanly. I *think* there's a javascript change needed to handle things completely correctly.